### PR TITLE
Update AUTHORS (remove duplicates)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -6,59 +6,58 @@ Contributors:
 Jim
 Palana
 fryshorts
-Richard Stanway
+R1CH
 BtbN
-Colin Edwards
+DDRBoxman
 Gol-D-Ace
 Shaolin
-John Bradley
+kc5nra
 Ryan Foster
 Zachary Lund
 cg2121
-Michael Fabian Dirks
+Xaymar
 SuslikV
-derrod
+Rodney
 Christoph Hohmann
-pkviet
+pkv
 Martell Malone
 HomeWorld
-Alex Anderson
 dodgepong
+Alex Anderson
 juvester
 Dmitry-Me
-Joel Bethke
+Fenrir
 Radzaquiel
 Socapex
 Cephas Reis
+Dillon Pentz
 Kurt Kartaltepe
-VodBox
 Luke Yelavich
 mntone
 sorayuki
 Andrew Surzhynskyi
-Michael Fabian 'Xaymar' Dirks
 Skyler Lipthay
 Arkkis
 Danni
 GoaLitiuM
 Hunter L. Allen
 Marvin Scholz
+Michel Snippe
 Quinn Damerell
+Tjienta Vara
 craftwar
 Clayton Groeneveld
+Ilya Melamed
 Jess Mayo
 Jimi Huotari
 Kris Moore
-Michel
 Alexandre Vicenzi
 Carl Fürstenberg
-Ilya Melamed
 Kilian von Pflugk
-Tjienta Vara
 Anry
 CoDEmanX
+H4ndy
 Ján Mlynek
-Manuel Kroeber
 nleseul
 Benjamin Klettbach
 Bird, Christopher
@@ -69,9 +68,8 @@ Daniel Lopez
 David Cooper
 Exeldro
 Jeremiah Senkpiel
-John R. Bradley
 Joseph El-Khouri
-Matt Gajownik
+Matt WizardCM
 Palakis
 Philip Haynes
 Robin Hielscher
@@ -85,7 +83,6 @@ Alexander Schittler
 Andreas Reischuck
 Andrei Nistor
 Azat Khasanshin
-Ben Torell
 Brian S. Stephan
 Chaturbate
 Dead133
@@ -100,7 +97,6 @@ Matt Morrissette
 Matthew McNamara
 Michael Goulet
 Skid-Inc
-Take Vos
 Taylor Blau
 Tristan Matthews
 Warchamp7
@@ -168,7 +164,6 @@ Haden F
 Han-Tai Chen
 Hicham LEMGHARI
 Iblis Lin
-Ilya M
 J Lynn
 J.D. Purcell
 Jake Probst
@@ -185,7 +180,6 @@ Kazuki Oishi
 Kevin
 Kevin Tardif
 Lasse Dalegaard
-Leonhard Oelke
 Lioncash
 Lukas Monka
 Makeenon
@@ -196,7 +190,6 @@ Matthew Szatmary
 MedicMomcilo
 Micah Elizabeth Scott
 Michael Hoang
-Michel Snippe
 Momcilo Medic
 Murnux
 Nicolas F
@@ -234,7 +227,6 @@ Weikardzaena
 Will Jamieson
 William Casarin
 Wouter
-Xaymar
 Younes SERRAJ
 Yvo
 Ziemas
@@ -259,7 +251,6 @@ mhabedinpour
 michael bishop
 nd
 notmark
-palana
 pantonvich
 partouf
 pipll


### PR DESCRIPTION
I used a custom private mailmap to remove the duplicates in Shaolin
initial list and to rename a few authors.
The mailmap I used is not committed to avoid spam.